### PR TITLE
Fix parity check in ps2_receive()

### DIFF
--- a/ps2pico.c
+++ b/ps2pico.c
@@ -130,7 +130,7 @@ void ps2_receive(uint32_t fifo) {
     parity = parity ^ (fifo >> i & 1);
   }
   
-  if(parity != fifo & 0x100) {
+  if(parity != fifo >> 8) {
     ps2_send(0xfe);
     return;
   }


### PR DESCRIPTION
The old condition `parity != fifo & 0x100`, which was actually interpreted as `(parity != fifo) & 0x100`, was always false. Furthermore, if the condition was written as intended (`parity != (fifo & 0x100)`), it would have been always true when `parity == 1`.